### PR TITLE
Adding in new ticket redirect

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -21,4 +21,11 @@ exports.createPages = ({ actions }) => {
     redirectInBrowser: true,
     force: true,
   })
+  createRedirect({
+    fromPath: "/tickets",
+    toPath: "https://www.iticket.co.nz/events/2022/aug/charlie-internship-lottery",
+    isPermanent: true,
+    redirectInBrowser: true,
+    force: true,
+  })
 }


### PR DESCRIPTION
Adding in a new redirect link to go to the ticket website for the new charlie and the internship lottery
[https://www.iticket.co.nz/events/2022/aug/charlie-internship-lottery](https://www.iticket.co.nz/events/2022/aug/charlie-internship-lottery)